### PR TITLE
fix: identity-provider-link syntax error

### DIFF
--- a/src/main/resources/theme/mustache/email/html/identity-provider-link.mustache
+++ b/src/main/resources/theme/mustache/email/html/identity-provider-link.mustache
@@ -1,5 +1,5 @@
 <html>
 <body>
-    <p>Someone wants to link your <b>{{realmName}}</b> account with <b>{{identityProviderDisplayName}}</b> account of user {{identityProviderContext.username}}. If this was you, click the link below to link accounts.</p><p><a href="{link}">Link to confirm account linking</a></p><p>This link will expire within {{#linkExpirationFormatter}}{{linkExpiration}}{{/linkExpirationFormatter}}.</p><p>If you don't want to link account, just ignore this message. If you link accounts, you will be able to login to {{realmName}} through {{identityProviderDisplayName}}.</p>
+    <p>Someone wants to link your <b>{{realmName}}</b> account with <b>{{identityProviderDisplayName}}</b> account of user {{identityProviderContext.username}}. If this was you, click the link below to link accounts.</p><p><a href="{{link}}">Link to confirm account linking</a></p><p>This link will expire within {{#linkExpirationFormatter}}{{linkExpiration}}{{/linkExpirationFormatter}}.</p><p>If you don't want to link account, just ignore this message. If you link accounts, you will be able to login to {{realmName}} through {{identityProviderDisplayName}}.</p>
 </body>
 </html>


### PR DESCRIPTION
Emails don't contain a working link, as the template is incorrectly using `{link}` instead of `{{link}}`.