### PR TITLE
Add boolean attribute for each supported locale

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/themes/theme/FreeMarkerAndMustacheEmailTemplateProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/theme/FreeMarkerAndMustacheEmailTemplateProvider.java
@@ -56,6 +56,14 @@ public class FreeMarkerAndMustacheEmailTemplateProvider extends FreeMarkerEmailT
       Theme theme = getTheme();
       Locale locale = session.getContext().resolveLocale(user);
       attributes.put("locale", locale);
+
+      // Expose locale_xy flags
+      realm.getSupportedLocalesStream().forEach(loc -> {
+              String key = String.format("locale_%s", loc);
+              Boolean ok = locale.getLanguage().equals(new Locale(loc).getLanguage());
+              attributes.put(key, ok);
+          });
+
       KeycloakUriInfo uriInfo = session.getContext().getUri();
       Properties rb = new Properties();
       if (!StringUtil.isNotBlank(realm.getDefaultLocale())) {

--- a/src/main/java/io/phasetwo/keycloak/themes/theme/FreeMarkerAndMustacheEmailTemplateProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/theme/FreeMarkerAndMustacheEmailTemplateProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Stream;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.email.EmailException;
 import org.keycloak.email.freemarker.FreeMarkerEmailTemplateProvider;
@@ -58,11 +59,14 @@ public class FreeMarkerAndMustacheEmailTemplateProvider extends FreeMarkerEmailT
       attributes.put("locale", locale);
 
       // Expose locale_xy flags
-      realm.getSupportedLocalesStream().forEach(loc -> {
-              String key = String.format("locale_%s", loc);
-              Boolean ok = locale.getLanguage().equals(new Locale(loc).getLanguage());
-              attributes.put(key, ok);
-          });
+      Stream stream = realm.getSupportedLocalesStream();
+      if (stream != null) {
+          stream.forEach(loc -> {
+                  String key = String.format("locale_%s", loc);
+                  Boolean ok = locale.getLanguage().equals(loc);
+                  attributes.put(key, ok);
+              });
+      }
 
       KeycloakUriInfo uriInfo = session.getContext().getUri();
       Properties rb = new Properties();


### PR DESCRIPTION
This small change expose attributes like `locale_en`, `locale_fr`, etc in the template attributes for each supported locale.
This allows to structure templates like this:

```
<html>
<body>

{{#locale_en}}... english content...{{/locale_en}}

{{#locale_fr}}... contenu en français...{{/locale_fr}}
</body>
</html>
```

It should be a viable solution for i18n when the amount of locales stays limited.

FTR this is my first foray in the codebase, I hope it fit the overall philosophy and guidelines of the project.