### PR TITLE
feat(login-theme): expand theme.v2.* brand tokens to shadcn CSS 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,13 +74,66 @@ There are login themes available.
 All themes assume you will store the values as Realm attributes with the following keys:
 
 - `_providerConfig.assets.login.css`: CSS you want to be loaded after the standard login.css
-- `_providerConfig.assets.login.backgroundColor`: override for `--pf-v5-global--primary-color--100`.
-- `_providerConfig.assets.login.primaryColor`: override for `--pf-v5-global--secondary-color--100`.
-- `_providerConfig.assets.login.secondaryColor`: override for `--pf-v5-global--BackgroundColor--100`.
+- `_providerConfig.assets.login.primaryColor`: override for `--pf-v5-global--primary-color--100` (also drives `--active-color--100`, `--primary-color--dark-100`, `--link--Color`, `--link--Color--dark` and `--keycloak-card-top-color`).
+- `_providerConfig.assets.login.secondaryColor`: override for `--pf-v5-global--primary-color--200` (also drives `--link--Color--hover` and `--link--Color--dark--hover`).
+- `_providerConfig.assets.login.backgroundColor`: override for `--pf-v5-global--BackgroundColor--100`.
 - `_providerConfig.assets.logo.url`: URL of logo file that will be served as the `div.kc-logo-text.background-image`. Constrained to 150x150.
 - `_providerConfig.assets.favicon.url`: URL of the favicon
 
 The `attributes` and `attributes-v2` themes consume the PatternFly-oriented CSS variables generated from these attributes. The `phasetwo-ui` theme is built with Keycloakify and shadcn, and consumes additional custom CSS variables emitted by the same `/realms/<realm>/assets/css/login.css` endpoint.
+
+#### Brand tokens (`phasetwo-ui`, since 0.73)
+
+`phasetwo-ui` is themed with a set of **brand tokens** stored one per Realm attribute
+under `_providerConfig.assets.theme.v2.`. The `/realms/<realm>/assets/css/login.css`
+endpoint resolves them and emits the full shadcn variable set as `:root` (light) and
+`.dark` (dark), after the legacy `--p2-login-*` block and before your custom CSS — so
+`_providerConfig.assets.login.css` still wins over everything.
+
+Editable tokens (append to the prefix above):
+
+| Token | Notes |
+| --- | --- |
+| `background`, `foreground` | page surface and body text |
+| `primary`, `primaryForeground` | brand color and text on it |
+| `secondary`, `secondaryForeground` | secondary brand color and text on it |
+| `muted`, `mutedForeground` | de-emphasized surface and text |
+| `border` | default border color |
+| `card`, `cardForeground` | derived from `background`/`foreground` when unset |
+| `accent`, `accentForeground` | derived from `muted`/`foreground` when unset |
+| `input` | derived from `border` when unset |
+| `ring` | focus ring; derived from `primary` when unset |
+| `radius` | a CSS length, e.g. `0.625rem` |
+| `fontFamily` | emitted as `--font-sans` |
+
+Each color token takes an optional dark override named `dark<Token>` — e.g.
+`_providerConfig.assets.theme.v2.darkBackground`.
+
+Resolution, per token, first valid value wins:
+
+1. `_providerConfig.assets.theme.v2.<token>` (or `dark<Token>` in dark mode)
+2. the legacy attribute, where one exists — `primary` ← `login.primaryColor`,
+   `secondary` ← `login.secondaryColor`, `background` ← `login.backgroundColor`,
+   `primaryForeground` ← `login.primaryForegroundColor` (dark reads the `-dark`
+   suffixed form, e.g. `login.primaryColor-dark`). The neutrals have no legacy
+   equivalent and go straight to the default.
+3. the built-in default for that mode
+
+Three behaviors worth knowing:
+
+- **Brand color is mode-independent.** If you set `primary` or `secondary` and leave the
+  dark override unset, dark mode inherits your light value rather than reverting to the
+  default palette. Surface and neutral tokens do not inherit — a light `background` will
+  never light up dark mode.
+- **Foregrounds auto-contrast.** Set `primary` without `primaryForeground` and a readable
+  near-black or near-white is chosen from the background's WCAG luminance.
+- **Values are validated.** A hex color, a bare CSS color keyword, a single
+  `rgb()`/`hsl()`/`hwb()`/`lab()`/`lch()`/`oklab()`/`oklch()` function, or (for `radius`)
+  a CSS length. Anything else is ignored and the next candidate applies.
+
+A realm that sets no `theme.v2.*` attribute renders exactly as it did before, via the
+legacy fallback. These tokens are consumed by `phasetwo-ui` only — the PatternFly
+`attributes` and `attributes-v2` themes are unaffected.
 
 #### Example CSS overrides
 

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/AssetsResourceProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/AssetsResourceProvider.java
@@ -2,7 +2,10 @@ package io.phasetwo.keycloak.themes.resource;
 
 import com.google.common.base.Strings;
 import com.google.common.io.CharSource;
-import jakarta.ws.rs.*;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.NotFoundException;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.core.Context;
 import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.Response;
@@ -13,6 +16,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import lombok.extern.jbosslog.JBossLog;
 import org.keycloak.models.KeycloakSession;
+import org.keycloak.models.RealmModel;
 import org.keycloak.services.Urls;
 import org.keycloak.services.resource.RealmResourceProvider;
 import org.keycloak.theme.Theme;
@@ -130,11 +134,16 @@ public class AssetsResourceProvider implements RealmResourceProvider {
   @Produces("text/css")
   public Response cssLogin(@Context HttpHeaders headers, @Context UriInfo uriInfo)
       throws IOException {
-    String customCss = session.getContext().getRealm().getAttribute(ASSETS_LOGIN_CSS);
+    RealmModel realm = session.getContext().getRealm();
+    String customCss = realm.getAttribute(ASSETS_LOGIN_CSS);
     StringBuilder o = new StringBuilder("/* custom login css */\n");
     o.append(":root {\n");
     setColors(o);
     o.append("}\n");
+    // Shared theme.v2.* brand tokens expanded to shadcn variables for the login
+    // surface. Emitted after the legacy --p2-login-* block and before any custom
+    // CSS, so hand-written CSS still wins.
+    o.append("\n").append(LoginThemeCss.render(realm::getAttribute));
     if (!Strings.isNullOrEmpty(customCss)) {
       o.append("\n").append(customCss);
     }

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/AssetsResourceProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/AssetsResourceProvider.java
@@ -140,9 +140,8 @@ public class AssetsResourceProvider implements RealmResourceProvider {
     o.append(":root {\n");
     setColors(o);
     o.append("}\n");
-    // Shared theme.v2.* brand tokens expanded to shadcn variables for the login
-    // surface. Emitted after the legacy --p2-login-* block and before any custom
-    // CSS, so hand-written CSS still wins.
+    // theme.v2.* brand tokens expanded to shadcn variables. Emitted after the legacy
+    // --p2-login-* block and before any custom CSS, so hand-written CSS still wins.
     o.append("\n").append(LoginThemeCss.render(realm::getAttribute));
     if (!Strings.isNullOrEmpty(customCss)) {
       o.append("\n").append(customCss);

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
@@ -46,6 +46,14 @@ public final class LoginThemeCss {
           "border");
 
   /**
+   * The brand tokens. Brand color is mode-independent (O-5): when a realm sets one of
+   * these for light and leaves the dark override unset, dark mode inherits the light
+   * value instead of dropping back to the stock dark palette — otherwise a custom
+   * brand color would silently revert to the default blue in dark mode.
+   */
+  static final List<String> BRAND_TOKENS = List.of("primary", "secondary");
+
+  /**
    * Tokens with no static default: when the realm sets none, they fall back to the
    * resolved value of a base token, so a lone custom primary also moves the ring, a
    * lone custom background the card surface, etc. A theme that sets every token
@@ -154,13 +162,37 @@ public final class LoginThemeCss {
     return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
   }
 
+  /**
+   * One mode's resolution: the final value of every token, plus which of them the realm
+   * actually set (as opposed to inherited or defaulted). The latter is what drives
+   * foreground auto-contrast and dark brand inheritance.
+   */
+  static final class Resolution {
+    final Map<String, String> resolved;
+    final Map<String, String> explicit;
+
+    Resolution(Map<String, String> resolved, Map<String, String> explicit) {
+      this.resolved = resolved;
+      this.explicit = explicit;
+    }
+  }
+
   /** Resolve every token for one mode: base tokens then derived. */
   static Map<String, String> resolve(Function<String, String> attr, boolean dark) {
+    Resolution light = resolveMode(attr, false, null);
+    return dark ? resolveMode(attr, true, light).resolved : light.resolved;
+  }
+
+  /**
+   * Resolve one mode. {@code light} is the already-resolved light mode when resolving
+   * dark, so unset dark brand tokens can inherit it (O-5); null when resolving light.
+   */
+  static Resolution resolveMode(Function<String, String> attr, boolean dark, Resolution light) {
     Map<String, String> defaults = dark ? DARK_DEFAULTS : LIGHT_DEFAULTS;
     Map<String, String> out = new LinkedHashMap<>();
     Map<String, String> explicit = new LinkedHashMap<>(); // v2/legacy only, pre-default
 
-    // Base tokens: v2 -> legacy -> static default.
+    // Base tokens: v2 -> legacy -> (dark brand only) the light value -> static default.
     for (String token : BASE_TOKENS) {
       String v2 = attr.apply(V2_PREFIX + (dark ? "dark" + capitalize(token) : token));
       String legacy = null;
@@ -169,6 +201,13 @@ public final class LoginThemeCss {
         legacy = attr.apply(LEGACY_PREFIX + suffix + (dark ? "-dark" : ""));
       }
       String set = pickColor(v2, legacy);
+      // A dark brand token the realm left unset inherits the light value it *did* set.
+      // Reading light.explicit (not light.resolved) keeps the all-default case on the
+      // dark palette, and treating the inherited value as explicit here lets the
+      // foreground below auto-contrast against it.
+      if (set == null && dark && light != null && BRAND_TOKENS.contains(token)) {
+        set = light.explicit.get(token);
+      }
       explicit.put(token, set);
       out.put(token, set != null ? set : defaults.get(token));
     }
@@ -185,7 +224,7 @@ public final class LoginThemeCss {
       String set = pickColor(v2);
       out.put(token, set != null ? set : out.get(e.getValue()));
     }
-    return out;
+    return new Resolution(out, explicit);
   }
 
   private static void autoContrast(
@@ -197,19 +236,19 @@ public final class LoginThemeCss {
 
   /** Render the full {@code :root} + {@code .dark} shadcn block for a realm. */
   public static String render(Function<String, String> attr) {
-    Map<String, String> light = resolve(attr, false);
-    Map<String, String> dark = resolve(attr, true);
+    Resolution light = resolveMode(attr, false, null);
+    Resolution dark = resolveMode(attr, true, light);
 
     String radius = attr.apply(V2_PREFIX + "radius");
     String font = attr.apply(V2_PREFIX + "fontFamily");
 
     StringBuilder o = new StringBuilder();
     o.append("/* phase-two theme tokens */\n:root {\n");
-    expand(o, light);
+    expand(o, light.resolved);
     if (isLength(radius)) o.append("  --radius: ").append(radius.trim()).append(";\n");
     if (!Strings.isNullOrEmpty(font)) o.append("  --font-sans: ").append(font.trim()).append(";\n");
     o.append("}\n.dark {\n");
-    expand(o, dark);
+    expand(o, dark.resolved);
     o.append("}\n");
     return o.toString();
   }

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
@@ -8,21 +8,19 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 /**
- * Builds the shadcn CSS-variable block for a realm's login theme from the shared
- * {@code _providerConfig.assets.theme.v2.*} brand tokens.
+ * Builds the shadcn CSS-variable block for a realm's login theme from its
+ * {@code _providerConfig.assets.theme.v2.*} brand-token attributes.
  *
- * <p>This is the login surface's side of the cross-surface token contract — see
- * {@code docs/theme-editor/design-and-execution.md} §7.1 (the canonical output) and
- * the dashboard's {@code expandThemeTokens}. Each of the editable tokens is resolved
- * {@code v2 -> legacy -> default}, validated, foregrounds auto-contrast when unset,
- * and the result is expanded to the full shadcn variable set emitted as {@code :root}
- * (light) and {@code .dark} (dark).
+ * <p>Each editable token is resolved {@code v2 -> legacy -> default}, validated, and
+ * (for the primary/secondary foregrounds) auto-contrasted when unset. The resolved
+ * values are expanded into the full set of shadcn CSS variables, emitted as
+ * {@code :root} (light) and {@code .dark} (dark).
  *
- * <p>The emitted block is appended to {@code /assets/css/login.css} after the legacy
- * {@code --p2-login-*} block, and loads after the theme's compiled stylesheet, so the
- * standard shadcn variables here win over the theme's built-in defaults. Realms that
- * set no {@code theme.v2.*} attribute fall back to legacy attributes and then these
- * defaults, so the output is unchanged for them.
+ * <p>The block is appended to {@code /assets/css/login.css} after the legacy
+ * {@code --p2-login-*} variables and loads after the theme's compiled stylesheet, so
+ * these variables take precedence over the theme's built-in defaults. A realm that
+ * sets no {@code theme.v2.*} attribute falls back to legacy attributes and then these
+ * defaults, leaving its output unchanged.
  */
 public final class LoginThemeCss {
 
@@ -33,7 +31,7 @@ public final class LoginThemeCss {
 
   /**
    * The base color tokens — the ones with a static default. Every other emitted
-   * variable derives from one of these (see {@link #DERIVED_FROM} and §7.1).
+   * variable derives from one of these (see {@link #DERIVED_FROM}).
    */
   static final List<String> BASE_TOKENS =
       List.of(
@@ -50,8 +48,8 @@ public final class LoginThemeCss {
   /**
    * Tokens with no static default: when the realm sets none, they fall back to the
    * resolved value of a base token, so a lone custom primary also moves the ring, a
-   * lone custom background the card surface, etc. (§7.1 "…else X"). Editor-authored
-   * themes set all of these explicitly, so this only affects partial/legacy realms.
+   * lone custom background the card surface, etc. A theme that sets every token
+   * explicitly is unaffected; this only matters for realms that set a subset.
    */
   static final Map<String, String> DERIVED_FROM =
       Map.of(
@@ -62,7 +60,7 @@ public final class LoginThemeCss {
           "input", "border",
           "ring", "primary");
 
-  /** Base-token light defaults — the login palette (mirror of DEFAULT_LIGHT_TOKENS, O-4). */
+  /** Base-token light defaults (the default login palette). */
   static final Map<String, String> LIGHT_DEFAULTS =
       Map.ofEntries(
           Map.entry("background", "#ffffff"),
@@ -75,7 +73,7 @@ public final class LoginThemeCss {
           Map.entry("mutedForeground", "#71717a"),
           Map.entry("border", "#e4e4e7"));
 
-  /** Base-token dark defaults (mirror of DEFAULT_DARK_TOKENS). */
+  /** Base-token dark defaults. */
   static final Map<String, String> DARK_DEFAULTS =
       Map.ofEntries(
           Map.entry("background", "#0a0a0a"),
@@ -101,7 +99,7 @@ public final class LoginThemeCss {
           "primaryForeground", "primaryForegroundColor");
 
   // Value validation — these strings are interpolated verbatim into a <style>, so an
-  // unchecked `red}` would terminate the rule early. Mirrors the portal resolver.
+  // unchecked value like `red}` would terminate the rule early.
   private static final Pattern HEX =
       Pattern.compile("^#(?:[0-9a-f]{3}|[0-9a-f]{6})$", Pattern.CASE_INSENSITIVE);
   private static final Pattern KEYWORD = Pattern.compile("^[a-z]+$", Pattern.CASE_INSENSITIVE);
@@ -216,7 +214,7 @@ public final class LoginThemeCss {
     return o.toString();
   }
 
-  /** Emit the shadcn variables for one resolved mode (§7.1). */
+  /** Emit the shadcn variables for one resolved mode. */
   private static void expand(StringBuilder o, Map<String, String> t) {
     v(o, "--background", t.get("background"));
     v(o, "--foreground", t.get("foreground"));

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
@@ -1,0 +1,256 @@
+package io.phasetwo.keycloak.themes.resource;
+
+import com.google.common.base.Strings;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.regex.Pattern;
+
+/**
+ * Builds the shadcn CSS-variable block for a realm's login theme from the shared
+ * {@code _providerConfig.assets.theme.v2.*} brand tokens.
+ *
+ * <p>This is the login surface's side of the cross-surface token contract — see
+ * {@code docs/theme-editor/design-and-execution.md} §7.1 (the canonical output) and
+ * the dashboard's {@code expandThemeTokens}. Each of the editable tokens is resolved
+ * {@code v2 -> legacy -> default}, validated, foregrounds auto-contrast when unset,
+ * and the result is expanded to the full shadcn variable set emitted as {@code :root}
+ * (light) and {@code .dark} (dark).
+ *
+ * <p>The emitted block is appended to {@code /assets/css/login.css} after the legacy
+ * {@code --p2-login-*} block, and loads after the theme's compiled stylesheet, so the
+ * standard shadcn variables here win over the theme's built-in defaults. Realms that
+ * set no {@code theme.v2.*} attribute fall back to legacy attributes and then these
+ * defaults, so the output is unchanged for them.
+ */
+public final class LoginThemeCss {
+
+  private LoginThemeCss() {}
+
+  static final String V2_PREFIX = "_providerConfig.assets.theme.v2.";
+  static final String LEGACY_PREFIX = "_providerConfig.assets.login.";
+
+  /**
+   * The base color tokens — the ones with a static default. Every other emitted
+   * variable derives from one of these (see {@link #DERIVED_FROM} and §7.1).
+   */
+  static final List<String> BASE_TOKENS =
+      List.of(
+          "background",
+          "foreground",
+          "primary",
+          "primaryForeground",
+          "secondary",
+          "secondaryForeground",
+          "muted",
+          "mutedForeground",
+          "border");
+
+  /**
+   * Tokens with no static default: when the realm sets none, they fall back to the
+   * resolved value of a base token, so a lone custom primary also moves the ring, a
+   * lone custom background the card surface, etc. (§7.1 "…else X"). Editor-authored
+   * themes set all of these explicitly, so this only affects partial/legacy realms.
+   */
+  static final Map<String, String> DERIVED_FROM =
+      Map.of(
+          "card", "background",
+          "cardForeground", "foreground",
+          "accent", "muted",
+          "accentForeground", "foreground",
+          "input", "border",
+          "ring", "primary");
+
+  /** Base-token light defaults — the login palette (mirror of DEFAULT_LIGHT_TOKENS, O-4). */
+  static final Map<String, String> LIGHT_DEFAULTS =
+      Map.ofEntries(
+          Map.entry("background", "#ffffff"),
+          Map.entry("foreground", "#0a0a0a"),
+          Map.entry("primary", "#3b82f6"),
+          Map.entry("primaryForeground", "#ffffff"),
+          Map.entry("secondary", "#60a5fa"),
+          Map.entry("secondaryForeground", "#0a0a0a"),
+          Map.entry("muted", "#f4f4f5"),
+          Map.entry("mutedForeground", "#71717a"),
+          Map.entry("border", "#e4e4e7"));
+
+  /** Base-token dark defaults (mirror of DEFAULT_DARK_TOKENS). */
+  static final Map<String, String> DARK_DEFAULTS =
+      Map.ofEntries(
+          Map.entry("background", "#0a0a0a"),
+          Map.entry("foreground", "#fafafa"),
+          Map.entry("primary", "#3b82f6"),
+          Map.entry("primaryForeground", "#ffffff"),
+          Map.entry("secondary", "#1e3a5f"),
+          Map.entry("secondaryForeground", "#fafafa"),
+          Map.entry("muted", "#27272a"),
+          Map.entry("mutedForeground", "#a1a1aa"),
+          Map.entry("border", "#3f3f46"));
+
+  /**
+   * The only tokens with a legacy login fallback (the three structured colors the
+   * server has always supported, plus the primary foreground). Value is the legacy
+   * attribute's suffix under {@link #LEGACY_PREFIX}; dark reads the {@code -dark} form.
+   */
+  static final Map<String, String> LEGACY_SUFFIX =
+      Map.of(
+          "primary", "primaryColor",
+          "secondary", "secondaryColor",
+          "background", "backgroundColor",
+          "primaryForeground", "primaryForegroundColor");
+
+  // Value validation — these strings are interpolated verbatim into a <style>, so an
+  // unchecked `red}` would terminate the rule early. Mirrors the portal resolver.
+  private static final Pattern HEX =
+      Pattern.compile("^#(?:[0-9a-f]{3}|[0-9a-f]{6})$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern KEYWORD = Pattern.compile("^[a-z]+$", Pattern.CASE_INSENSITIVE);
+  private static final Pattern COLOR_FN =
+      Pattern.compile(
+          "^(?:rgba?|hsla?|hwb|lab|lch|oklab|oklch)\\([0-9a-z%.,+\\-/ ]*\\)$",
+          Pattern.CASE_INSENSITIVE);
+  private static final Pattern LENGTH = Pattern.compile("^(?:0|[0-9]*\\.?[0-9]+(?:px|rem|em))$");
+
+  static boolean isColor(String v) {
+    if (v == null) return false;
+    String t = v.trim();
+    return HEX.matcher(t).matches()
+        || KEYWORD.matcher(t).matches()
+        || COLOR_FN.matcher(t).matches();
+  }
+
+  static boolean isLength(String v) {
+    return v != null && LENGTH.matcher(v.trim()).matches();
+  }
+
+  /** First candidate that is non-empty and a valid color, or null. */
+  private static String pickColor(String... candidates) {
+    for (String c : candidates) {
+      if (c != null) {
+        String t = c.trim();
+        if (!t.isEmpty() && isColor(t)) return t;
+      }
+    }
+    return null;
+  }
+
+  /** Readable near-black/white foreground for a hex background; white for non-hex. */
+  static String contrast(String background) {
+    String t = background == null ? "" : background.trim();
+    if (!HEX.matcher(t).matches()) return "#ffffff";
+    String hex = t.substring(1);
+    if (hex.length() == 3) {
+      StringBuilder b = new StringBuilder();
+      for (char c : hex.toCharArray()) b.append(c).append(c);
+      hex = b.toString();
+    }
+    double r = channel(Integer.parseInt(hex.substring(0, 2), 16));
+    double g = channel(Integer.parseInt(hex.substring(2, 4), 16));
+    double b = channel(Integer.parseInt(hex.substring(4, 6), 16));
+    double luminance = 0.2126 * r + 0.7152 * g + 0.0722 * b;
+    return luminance >= 0.5 ? "#18181b" : "#ffffff";
+  }
+
+  private static double channel(int c) {
+    double s = c / 255.0;
+    return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  }
+
+  /** Resolve every token for one mode: base tokens then derived. */
+  static Map<String, String> resolve(Function<String, String> attr, boolean dark) {
+    Map<String, String> defaults = dark ? DARK_DEFAULTS : LIGHT_DEFAULTS;
+    Map<String, String> out = new LinkedHashMap<>();
+    Map<String, String> explicit = new LinkedHashMap<>(); // v2/legacy only, pre-default
+
+    // Base tokens: v2 -> legacy -> static default.
+    for (String token : BASE_TOKENS) {
+      String v2 = attr.apply(V2_PREFIX + (dark ? "dark" + capitalize(token) : token));
+      String legacy = null;
+      String suffix = LEGACY_SUFFIX.get(token);
+      if (suffix != null) {
+        legacy = attr.apply(LEGACY_PREFIX + suffix + (dark ? "-dark" : ""));
+      }
+      String set = pickColor(v2, legacy);
+      explicit.put(token, set);
+      out.put(token, set != null ? set : defaults.get(token));
+    }
+
+    // Auto-contrast the two foregrounds when their base was set but they were not:
+    // a lone custom primary/secondary must not keep the default text color.
+    autoContrast(out, explicit, "primaryForeground", "primary");
+    autoContrast(out, explicit, "secondaryForeground", "secondary");
+
+    // Derived tokens: v2 -> the resolved base token.
+    for (Map.Entry<String, String> e : DERIVED_FROM.entrySet()) {
+      String token = e.getKey();
+      String v2 = attr.apply(V2_PREFIX + (dark ? "dark" + capitalize(token) : token));
+      String set = pickColor(v2);
+      out.put(token, set != null ? set : out.get(e.getValue()));
+    }
+    return out;
+  }
+
+  private static void autoContrast(
+      Map<String, String> out, Map<String, String> explicit, String fg, String bg) {
+    if (explicit.get(fg) == null && explicit.get(bg) != null) {
+      out.put(fg, contrast(out.get(bg)));
+    }
+  }
+
+  /** Render the full {@code :root} + {@code .dark} shadcn block for a realm. */
+  public static String render(Function<String, String> attr) {
+    Map<String, String> light = resolve(attr, false);
+    Map<String, String> dark = resolve(attr, true);
+
+    String radius = attr.apply(V2_PREFIX + "radius");
+    String font = attr.apply(V2_PREFIX + "fontFamily");
+
+    StringBuilder o = new StringBuilder();
+    o.append("/* phase-two theme tokens */\n:root {\n");
+    expand(o, light);
+    if (isLength(radius)) o.append("  --radius: ").append(radius.trim()).append(";\n");
+    if (!Strings.isNullOrEmpty(font)) o.append("  --font-sans: ").append(font.trim()).append(";\n");
+    o.append("}\n.dark {\n");
+    expand(o, dark);
+    o.append("}\n");
+    return o.toString();
+  }
+
+  /** Emit the shadcn variables for one resolved mode (§7.1). */
+  private static void expand(StringBuilder o, Map<String, String> t) {
+    v(o, "--background", t.get("background"));
+    v(o, "--foreground", t.get("foreground"));
+    v(o, "--card", t.get("card"));
+    v(o, "--card-foreground", t.get("cardForeground"));
+    v(o, "--popover", t.get("background"));
+    v(o, "--popover-foreground", t.get("foreground"));
+    v(o, "--primary", t.get("primary"));
+    v(o, "--primary-foreground", t.get("primaryForeground"));
+    v(o, "--secondary", t.get("secondary"));
+    v(o, "--secondary-foreground", t.get("secondaryForeground"));
+    v(o, "--muted", t.get("muted"));
+    v(o, "--muted-foreground", t.get("mutedForeground"));
+    v(o, "--accent", t.get("accent"));
+    v(o, "--accent-foreground", t.get("accentForeground"));
+    v(o, "--border", t.get("border"));
+    v(o, "--input", t.get("input"));
+    v(o, "--ring", t.get("ring"));
+    // sidebar-* derive from muted/border/primary/foreground (no tokens of their own).
+    v(o, "--sidebar", t.get("muted"));
+    v(o, "--sidebar-foreground", t.get("foreground"));
+    v(o, "--sidebar-primary", t.get("primary"));
+    v(o, "--sidebar-primary-foreground", t.get("primaryForeground"));
+    v(o, "--sidebar-accent", t.get("border"));
+    v(o, "--sidebar-accent-foreground", t.get("foreground"));
+    v(o, "--sidebar-border", t.get("border"));
+    v(o, "--sidebar-ring", t.get("primary"));
+  }
+
+  private static void v(StringBuilder o, String name, String value) {
+    o.append("  ").append(name).append(": ").append(value).append(";\n");
+  }
+
+  private static String capitalize(String s) {
+    return Character.toUpperCase(s.charAt(0)) + s.substring(1);
+  }
+}

--- a/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
+++ b/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
@@ -1,0 +1,111 @@
+package io.phasetwo.keycloak.themes.resource;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+
+/** Pure unit tests for the login theme.v2.* -> shadcn expansion (no container). */
+public class LoginThemeCssTest {
+
+  private static Function<String, String> attrs(Map<String, String> m) {
+    return m::get;
+  }
+
+  private static Map<String, String> map(String... kv) {
+    Map<String, String> m = new HashMap<>();
+    for (int i = 0; i < kv.length; i += 2) m.put(kv[i], kv[i + 1]);
+    return m;
+  }
+
+  @Test
+  public void emitsLoginPaletteDefaultsWhenNothingSet() {
+    String css = LoginThemeCss.render(attrs(map()));
+
+    // Light defaults + a derived variable, then the .dark block.
+    assertTrue(css.contains("--primary: #3b82f6;"), css);
+    assertTrue(css.contains("--background: #ffffff;"), css);
+    assertTrue(css.contains("--sidebar-primary: #3b82f6;"), css);
+    assertTrue(css.contains("--popover: #ffffff;"), css);
+    assertTrue(css.contains(".dark {"), css);
+    assertTrue(css.contains("--background: #0a0a0a;"), css);
+    // No radius/font emitted when unset.
+    assertFalse(css.contains("--radius:"), css);
+    assertFalse(css.contains("--font-sans:"), css);
+  }
+
+  @Test
+  public void v2TokenDrivesPrimaryAndItsDerivations() {
+    String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "#7c3aed")));
+
+    assertTrue(css.contains("--primary: #7c3aed;"), css);
+    assertTrue(css.contains("--ring: #7c3aed;"), css);
+    assertTrue(css.contains("--sidebar-primary: #7c3aed;"), css);
+  }
+
+  @Test
+  public void fallsBackToLegacyLoginColorWhenV2Unset() {
+    String css =
+        LoginThemeCss.render(attrs(map(LoginThemeCss.LEGACY_PREFIX + "primaryColor", "#ff0000")));
+    assertTrue(css.contains("--primary: #ff0000;"), css);
+  }
+
+  @Test
+  public void v2WinsOverLegacy() {
+    String css =
+        LoginThemeCss.render(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "primary", "#00ff00",
+                    LoginThemeCss.LEGACY_PREFIX + "primaryColor", "#ff0000")));
+    assertTrue(css.contains("--primary: #00ff00;"), css);
+    assertFalse(css.contains("--primary: #ff0000;"), css);
+  }
+
+  @Test
+  public void darkOverrideAppliesInDarkBlockOnly() {
+    String css =
+        LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "darkBackground", "#111827")));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(darkIdx > 0);
+    // The dark override shows up in the .dark block, and the light default stays.
+    assertTrue(css.substring(darkIdx).contains("--background: #111827;"), css);
+    assertTrue(css.substring(0, darkIdx).contains("--background: #ffffff;"), css);
+  }
+
+  @Test
+  public void autoContrastsForegroundWhenBaseSetButForegroundUnset() {
+    // A light primary with no explicit primary-foreground -> dark, readable text.
+    String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "#eeeeee")));
+    assertTrue(css.contains("--primary-foreground: #18181b;"), css);
+  }
+
+  @Test
+  public void invalidValueIsTreatedAsUnset() {
+    // A value that could break out of the rule is rejected -> default holds.
+    String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "red}; }")));
+    assertTrue(css.contains("--primary: #3b82f6;"), css);
+    assertFalse(css.contains("red}"), css);
+  }
+
+  @Test
+  public void emitsRadiusAndFontWhenValid() {
+    String css =
+        LoginThemeCss.render(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "radius", "0.5rem",
+                    LoginThemeCss.V2_PREFIX + "fontFamily", "Inter, sans-serif")));
+    assertTrue(css.contains("--radius: 0.5rem;"), css);
+    assertTrue(css.contains("--font-sans: Inter, sans-serif;"), css);
+  }
+
+  @Test
+  public void rejectsNonLengthRadius() {
+    String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "radius", "huge")));
+    assertFalse(css.contains("--radius:"), css);
+  }
+}

--- a/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
+++ b/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
@@ -77,6 +77,67 @@ public class LoginThemeCssTest {
   }
 
   @Test
+  public void darkBrandTokensInheritTheLightValueWhenUnset() {
+    // Brand color is mode-independent (O-5): a realm that sets only the light brand
+    // color must not revert to the stock blue/navy in dark mode.
+    String css =
+        LoginThemeCss.render(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "primary", "#7c3aed",
+                    LoginThemeCss.V2_PREFIX + "secondary", "#c4b5fd")));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(darkIdx > 0);
+    String dark = css.substring(darkIdx);
+    assertTrue(dark.contains("--primary: #7c3aed;"), css);
+    assertTrue(dark.contains("--secondary: #c4b5fd;"), css);
+    // The stock dark brand defaults must not appear.
+    assertFalse(dark.contains("--primary: #3b82f6;"), css);
+    assertFalse(dark.contains("--secondary: #1e3a5f;"), css);
+  }
+
+  @Test
+  public void explicitDarkBrandOverrideBeatsTheLightValue() {
+    String css =
+        LoginThemeCss.render(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "primary", "#7c3aed",
+                    LoginThemeCss.V2_PREFIX + "darkPrimary", "#a78bfa")));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(css.substring(0, darkIdx).contains("--primary: #7c3aed;"), css);
+    assertTrue(css.substring(darkIdx).contains("--primary: #a78bfa;"), css);
+  }
+
+  @Test
+  public void darkSurfaceTokensDoNotInheritTheLightValue() {
+    // Only brand tokens are mode-independent — a light background must never light up
+    // dark mode. Regression guard for the O-5 carve-out.
+    String css =
+        LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "background", "#fef9c3")));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(css.substring(0, darkIdx).contains("--background: #fef9c3;"), css);
+    assertTrue(css.substring(darkIdx).contains("--background: #0a0a0a;"), css);
+  }
+
+  @Test
+  public void darkForegroundAutoContrastsAgainstAnInheritedBrandColor() {
+    // The inherited light brand color drives the dark foreground too, so a pale brand
+    // does not end up with white-on-pale text in dark mode.
+    String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "#eeeeee")));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(css.substring(darkIdx).contains("--primary-foreground: #18181b;"), css);
+  }
+
+  @Test
+  public void allDefaultsKeepTheDarkPaletteForBrandTokens() {
+    // Nothing set: dark brand tokens stay on the dark defaults rather than inheriting.
+    String css = LoginThemeCss.render(attrs(map()));
+    int darkIdx = css.indexOf(".dark {");
+    assertTrue(css.substring(darkIdx).contains("--secondary: #1e3a5f;"), css);
+  }
+
+  @Test
   public void autoContrastsForegroundWhenBaseSetButForegroundUnset() {
     // A light primary with no explicit primary-foreground -> dark, readable text.
     String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "#eeeeee")));


### PR DESCRIPTION
Adds runtime login theming from per-realm brand-token attributes.

## What
- New `LoginThemeCss` — reads a realm's `_providerConfig.assets.theme.v2.*` attributes, resolves each token (`v2 → legacy → default`, validated, and the primary/secondary foregrounds auto-contrasted when unset), and expands them into the full set of shadcn CSS variables, emitted as `:root` (light) and `.dark` (dark).
  - Base tokens carry static defaults (the default login palette). `card`/`cardForeground`/`accent`/`accentForeground`/`input`/`ring` derive from their base token when unset, so a lone custom `primary` also moves the ring, a custom `background` the card surface, etc. A theme that sets every token explicitly is unaffected.
- `AssetsResourceProvider` appends this block to `/assets/css/login.css`, after the legacy `--p2-login-*` variables and before any hand-written custom CSS (so custom CSS still wins). A realm with no `theme.v2.*` attribute renders exactly as before.
- Values are validated so a malformed attribute cannot break out of the `<style>` rule.

## Tests
- Pure unit tests (`LoginThemeCssTest`, no testcontainers): defaults, v2 override + derivations, legacy fallback, v2-over-legacy precedence, dark-only override, foreground auto-contrast, invalid-value rejection, radius/font. 9/9 green.
- Also replaced a pre-existing `jakarta.ws.rs.*` wildcard import that spotless flagged once the file was touched.

## Notes
- No theme `index.css` change needed: the theme already defines these shadcn variables, and this block loads after the compiled stylesheet, so the emitted values win. Worth confirming end-to-end via the local docker-compose (set `theme.v2.*` attributes on the seeded realm and open the login page) before merge.
