### PR TITLE
Fix: organization admin UI should not require view-clients

### DIFF
--- a/themes/phasetwo-ui/src/.gitignore
+++ b/themes/phasetwo-ui/src/.gitignore
@@ -2,6 +2,7 @@
 
 # === Owned files start ===
 # account/KcAccountUi.tsx
+# admin/ForbiddenSection.tsx
 # admin/help-urls.ts
 # admin/index.css
 # admin/PageHeader.tsx
@@ -122,7 +123,6 @@
 /admin/Banners.tsx
 /admin/colorScheme.ts
 /admin/environment.ts
-/admin/ForbiddenSection.tsx
 /admin/i18next.d.ts
 /admin/KcAdminUi.tsx
 /admin/KcContext.ts

--- a/themes/phasetwo-ui/src/admin/ForbiddenSection.tsx
+++ b/themes/phasetwo-ui/src/admin/ForbiddenSection.tsx
@@ -1,0 +1,48 @@
+/**
+ * This file has been claimed for ownership from @keycloakify/keycloak-admin-ui version 260502.0.0.
+ * To relinquish ownership and restore this file to its original content, run the following command:
+ * 
+ * $ npx keycloakify own --path "admin/ForbiddenSection.tsx" --revert
+ */
+
+/* eslint-disable */
+
+// @ts-nocheck
+
+import { useTranslation } from "react-i18next";
+import { PageSection } from "../shared/@patternfly/react-core";
+
+import {
+  describeAccessType,
+  type ExtendedAccessType,
+} from "./phaseII/access/access";
+
+type ForbiddenSectionProps = {
+  permissionNeeded: ExtendedAccessType | ExtendedAccessType[];
+};
+
+export const ForbiddenSection = ({
+  permissionNeeded,
+}: ForbiddenSectionProps) => {
+  const { t } = useTranslation();
+  const permissionNeededArray = Array.isArray(permissionNeeded)
+    ? permissionNeeded
+    : [permissionNeeded];
+
+  const permissionNames = permissionNeededArray
+    .map(describeAccessType)
+    .filter((name) => name !== "");
+
+  return (
+    <PageSection>
+      {permissionNames.length === 0 ? (
+        t("forbiddenAdminConsole")
+      ) : (
+        <>
+          {t("forbidden", { count: permissionNames.length })}{" "}
+          {permissionNames.join(", ")}
+        </>
+      )}
+    </PageSection>
+  );
+};

--- a/themes/phasetwo-ui/src/admin/phaseII/access/access.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/access/access.tsx
@@ -1,6 +1,69 @@
-import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
+import type {
+  AccessType,
+  AccessTypeFunc,
+} from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
 
-export type ExtendedAccessType =
-  | AccessType
+/**
+ * Realm-management roles added by the keycloak-orgs extension. They are not
+ * part of the upstream `AccessType` union, so they are declared here.
+ */
+export type OrganizationAccessType =
   | "view-organizations"
   | "manage-organizations";
+
+export type ExtendedAccessChecker = {
+  hasAll: (...types: ExtendedAccessType[]) => boolean;
+  hasAny: (...types: ExtendedAccessType[]) => boolean;
+};
+
+/**
+ * Used in place of a role name when access needs "any of these roles"
+ * semantics, which the array form cannot express because {@link AuthWall}
+ * evaluates it with AND. `label` is what gets shown in the
+ * {@link ForbiddenSection}, since a function has no meaningful name.
+ */
+export type ExtendedAccessTypeFunc = ((
+  accessChecker: ExtendedAccessChecker,
+) => boolean) & { label?: string };
+
+/**
+ * The upstream `AccessType`, plus the organization roles. The upstream
+ * function form is replaced by {@link ExtendedAccessTypeFunc} so that
+ * predicates can reference the organization roles too.
+ */
+export type ExtendedAccessType =
+  | Exclude<AccessType, AccessTypeFunc>
+  | OrganizationAccessType
+  | ExtendedAccessTypeFunc;
+
+/** Either of these grants access to the organizations admin UI. */
+export const ORGANIZATION_ROLES: OrganizationAccessType[] = [
+  "view-organizations",
+  "manage-organizations",
+];
+
+/**
+ * Access guard for the organizations section.
+ *
+ * The organizations UI only calls the keycloak-orgs endpoints under
+ * `/realms/{realm}/orgs`, which are authorized server-side with
+ * `view-organizations` (reads) and `manage-organizations` (writes). It never
+ * reads the clients API, so it must not require `view-clients`/`query-clients`:
+ * those also expose every client secret in the realm through
+ * `/admin/realms/{realm}/clients/{id}/client-secret`.
+ *
+ * `manage-organizations` is not a composite of `view-organizations`, so both
+ * have to be accepted here — and this must stay in sync with the left-nav
+ * check in `phaseII/navigation/extensions.tsx`, because `LeftNav` hides any
+ * item whose route access fails.
+ */
+export const hasOrganizationsAccess: ExtendedAccessTypeFunc = ({ hasAny }) =>
+  hasAny(...ORGANIZATION_ROLES);
+hasOrganizationsAccess.label = ORGANIZATION_ROLES.join(" or ");
+
+/**
+ * Human readable name for an access requirement. Predicates report their
+ * `label`, if they set one; anything else has no name to report.
+ */
+export const describeAccessType = (type: ExtendedAccessType): string =>
+  typeof type === "function" ? (type.label ?? "") : type;

--- a/themes/phasetwo-ui/src/admin/phaseII/custom-styles/components/SaveReset.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/custom-styles/components/SaveReset.tsx
@@ -1,5 +1,11 @@
 import { useTranslation } from "react-i18next";
-import { ActionGroup, ActionGroupProps, Button } from "@patternfly/react-core";
+import {
+  ActionGroup,
+  ActionGroupProps,
+  Button,
+  Tooltip,
+} from "@patternfly/react-core";
+import { useAccess } from "../../../context/access/Access";
 
 type SaveResetProps = ActionGroupProps & {
   name: string;
@@ -16,19 +22,43 @@ export const SaveReset = ({
   ...rest
 }: SaveResetProps) => {
   const { t } = useTranslation();
+  const { hasAccess } = useAccess();
+  // Saving custom styles writes realm attributes (PUT /admin/realms/{realm}),
+  // which the server authorizes with manage-realm. The route only requires
+  // view-realm, so a view-only admin can reach this page — disable Save for
+  // them rather than let the request 403 on click.
+  const canManageRealm = hasAccess("manage-realm");
+
+  const revertButton = (
+    <Button
+      isDisabled={!isActive}
+      data-testid={name + "Revert"}
+      variant="link"
+      onClick={reset}
+    >
+      {t("revert")}
+    </Button>
+  );
+
+  if (!canManageRealm) {
+    return (
+      <ActionGroup {...rest}>
+        <Tooltip content="You need the manage-realm role to save changes.">
+          <Button isAriaDisabled data-testid={name + "Save"}>
+            {t("save")}
+          </Button>
+        </Tooltip>
+        {revertButton}
+      </ActionGroup>
+    );
+  }
+
   return (
     <ActionGroup {...rest}>
       <Button isDisabled={!isActive} data-testid={name + "Save"} onClick={save}>
         {t("save")}
       </Button>
-      <Button
-        isDisabled={!isActive}
-        data-testid={name + "Revert"}
-        variant="link"
-        onClick={reset}
-      >
-        {t("revert")}
-      </Button>
+      {revertButton}
     </ActionGroup>
   );
 };

--- a/themes/phasetwo-ui/src/admin/phaseII/custom-styles/email/email-template.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/custom-styles/email/email-template.tsx
@@ -32,6 +32,7 @@ import { toRealmSettings } from "../../../realm-settings/routes/RealmSettings";
 
 import { TextAreaControl } from "@/shared/keycloak-ui-shared";
 import { useRealm } from "../../../context/realm-context/RealmContext";
+import { useAccess } from "../../../context/access/Access";
 import { SaveReset } from "../components/SaveReset";
 import useStylesFetcher from "../useStylesFetcher";
 import { useAdminClient } from "../../../admin-client";
@@ -177,6 +178,11 @@ export const EmailTemplate = ({ realm, refresh }: EmailTemplateTabProps) => {
   const { adminClient } = useAdminClient();
   const { t } = useTranslation();
   const { addAlert, addError } = useAlerts();
+  const { hasAccess } = useAccess();
+  // Every save on this tab writes realm attributes or email templates, both of
+  // which the server authorizes with manage-realm. The route only requires
+  // view-realm, so gate the mutating controls for view-only admins.
+  const canManageRealm = hasAccess("manage-realm");
   const { getEmailTemplates, getEmailTemplateValue, updateEmailTemplateValue } =
     useStylesFetcher();
   const logoInputRef = useRef<HTMLInputElement>(null);
@@ -404,7 +410,7 @@ export const EmailTemplate = ({ realm, refresh }: EmailTemplateTabProps) => {
             className="pf-v5-u-mt-sm"
             onClick={() => updateRealmTheme()}
             isLoading={updatingEmailTheme}
-            isDisabled={updatingEmailTheme}
+            isDisabled={updatingEmailTheme || !canManageRealm}
           >
             {updatingEmailTheme ? "Activating..." : "Activate"}
           </Button>
@@ -426,7 +432,7 @@ export const EmailTemplate = ({ realm, refresh }: EmailTemplateTabProps) => {
             className="pf-v5-u-mt-sm"
             onClick={() => updateRealmTheme()}
             isLoading={updatingEmailTheme}
-            isDisabled={updatingEmailTheme}
+            isDisabled={updatingEmailTheme || !canManageRealm}
           >
             {updatingEmailTheme ? "Upgrading..." : "Upgrade to phasetwo-ui"}
           </Button>
@@ -511,7 +517,7 @@ export const EmailTemplate = ({ realm, refresh }: EmailTemplateTabProps) => {
           <Button
             variant="primary"
             onClick={saveBranding}
-            isDisabled={!brandingDirty || isSavingBranding}
+            isDisabled={!brandingDirty || isSavingBranding || !canManageRealm}
             isLoading={isSavingBranding}
           >
             Save

--- a/themes/phasetwo-ui/src/admin/phaseII/custom-styles/routes/Styles.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/custom-styles/routes/Styles.tsx
@@ -16,7 +16,7 @@ export const StylesRoute: AppRouteObject = {
   path: "/:realm/ext-styles",
   element: <StylesSection />,
   handle: {
-    access: "query-clients",
+    access: "view-realm",
   },
   breadcrumb: (t) => t("styles"),
 };

--- a/themes/phasetwo-ui/src/admin/phaseII/navigation/extensions.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/navigation/extensions.tsx
@@ -2,12 +2,13 @@ import { NavGroup } from "@patternfly/react-core";
 import { useTranslation } from "react-i18next";
 import { LeftNav } from "../../PageNav";
 import { useAccess } from "../../context/access/Access";
+import { ORGANIZATION_ROLES } from "../access/access";
 
 const Extensions = () => {
   const { t } = useTranslation();
   const { hasSomeAccess } = useAccess();
 
-  const showOrgs = hasSomeAccess("view-organizations", "manage-organizations");
+  const showOrgs = hasSomeAccess(...ORGANIZATION_ROLES);
 
   return (
     <NavGroup aria-label={t("extensions")} title={t("extensions")}>

--- a/themes/phasetwo-ui/src/admin/phaseII/orgs/routes/Org.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/orgs/routes/Org.tsx
@@ -1,5 +1,6 @@
 import { generateEncodedPath } from "../../../utils/generateEncodedPath";
 import type { AppRouteObject } from "../../../routes";
+import { hasOrganizationsAccess } from "../../access/access";
 
 import { lazy } from "react";
 import { Path } from "react-router-dom";
@@ -27,7 +28,7 @@ export const OrgRoute: AppRouteObject = {
   element: <OrgDetails />,
   breadcrumb: (t) => t("orgDetails"),
   handle: {
-    access: "view-clients",
+    access: hasOrganizationsAccess,
   },
 };
 

--- a/themes/phasetwo-ui/src/admin/phaseII/orgs/routes/Orgs.tsx
+++ b/themes/phasetwo-ui/src/admin/phaseII/orgs/routes/Orgs.tsx
@@ -2,6 +2,7 @@ import { lazy } from "react";
 import { Path } from "react-router-dom";
 import type { AppRouteObject } from "../../../routes";
 import { generateEncodedPath } from "../../../utils/generateEncodedPath";
+import { hasOrganizationsAccess } from "../../access/access";
 
 export type OrgsParams = {
   realm: string;
@@ -14,7 +15,7 @@ export const OrgsRoute: AppRouteObject = {
   element: <OrgsSection />,
   breadcrumb: (t) => t("orgList"),
   handle: {
-    access: "query-clients",
+    access: hasOrganizationsAccess,
   },
 };
 

--- a/themes/phasetwo-ui/src/admin/routes.tsx
+++ b/themes/phasetwo-ui/src/admin/routes.tsx
@@ -9,7 +9,7 @@
 
 // @ts-nocheck
 
-import type { AccessType } from "@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation";
+import type { ExtendedAccessType } from "./phaseII/access/access";
 import type { TFunction } from "i18next";
 import type { ComponentType } from "react";
 import type { NonIndexRouteObject, RouteObject } from "react-router-dom";
@@ -36,7 +36,7 @@ import orgRoutes from "./phaseII/orgs/routes";
 import stylesRoutes from "./phaseII/custom-styles/routes";
 
 export type AppRouteObjectHandle = {
-  access: AccessType | AccessType[];
+  access: ExtendedAccessType | ExtendedAccessType[];
 };
 
 export interface AppRouteObject extends NonIndexRouteObject {


### PR DESCRIPTION
## What & why

The Organizations admin UI required `view-clients` / `query-clients`, which also grant read access to **every client secret in the realm** (`/admin/realms/{realm}/clients/{id}/client-secret`). A delegated org admin should never need that. This addresses p2-inc/phasetwo-admin-portal#194.

This migrates the fix from p2-inc/keycloak#250 into the `phasetwo-ui` theme, where the admin UI now lives as vendored source under `themes/phasetwo-ui/src/admin/` (the old keycloak-fork approach is superseded).

## Changes

- Re-gate the org list/detail routes on `view-organizations` / `manage-organizations` via a `hasOrganizationsAccess` predicate — view **or** manage, since `manage-organizations` is not a composite of `view-organizations`.
- Re-gate the custom-styles route on `view-realm` (was `query-clients`).
- `ForbiddenSection` now renders readable role labels for predicate-based access (with a `forbiddenAdminConsole` fallback) instead of dumping the function source; claimed via `keycloakify own`.
- **Added on top of #250:** disable the custom-styles Save controls (with an explanatory tooltip) for users who lack `manage-realm`. That page is reachable with `view-realm`, but every save writes realm attributes (`PUT /admin/realms/{realm}`), which the server authorizes with `manage-realm` — so a view-only admin would otherwise hit a 403 on click. Centralized in `SaveReset`, plus the email tab's non-`SaveReset` mutating buttons.

## Verification

- `tsc -b` and full `pnpm build` (vite + keycloakify) pass.
- Manual end-to-end against the `phasetwo-keycloak` image with a test user holding only `view-realm` + `view-organizations`:
  - Extensions nav shows Organizations + Styles; org list and detail load with **no** `view-clients`; Clients section is absent from the nav.
  - All mutations correctly gated — org Attributes, every Styles tab, and the email buttons show a disabled Save with the manage-realm tooltip.

---

Supersedes p2-inc/keycloak#250 · addresses p2-inc/phasetwo-admin-portal#194. Original fix co-authored with @Emad-Hajiabadi.
