### PR TITLE
feat(email): brand the email template from the shared theme tokens

### DIFF
--- a/src/main/java/io/phasetwo/keycloak/email/DefaultAttributesBuilderProvider.java
+++ b/src/main/java/io/phasetwo/keycloak/email/DefaultAttributesBuilderProvider.java
@@ -1,6 +1,7 @@
 package io.phasetwo.keycloak.email;
 
 import com.google.common.base.Strings;
+import io.phasetwo.keycloak.themes.resource.LoginThemeCss;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -40,6 +41,17 @@ public class DefaultAttributesBuilderProvider implements AttributesBuilderProvid
     String footerLine2 = realm.getAttribute(FOOTER_LINE2_ATTRIBUTE);
     if (!Strings.isNullOrEmpty(footerLine2)) {
       branding.put("footerLine2", footerLine2);
+    }
+
+    // Brand tokens the realm has explicitly set, resolved by the same code the login
+    // page uses so the two cannot disagree. Email clients do not support CSS variables,
+    // so these are interpolated into inline styles by the template; only tokens the
+    // realm actually set are passed, letting the template's own defaults stand
+    // otherwise. Light only -- dark-mode handling across email clients is too
+    // inconsistent to target.
+    Map<String, String> theme = LoginThemeCss.explicitLightTokens(realm::getAttribute);
+    if (!theme.isEmpty()) {
+      branding.put("theme", theme);
     }
 
     if (!branding.isEmpty()) {

--- a/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
+++ b/src/main/java/io/phasetwo/keycloak/themes/resource/LoginThemeCss.java
@@ -234,6 +234,32 @@ public final class LoginThemeCss {
     }
   }
 
+  /**
+   * The light brand tokens the realm has actually set, for surfaces that cannot use CSS
+   * variables and must have values interpolated server-side — the email theme.
+   *
+   * Deliberately only the tokens with an explicit {@code v2} or legacy value, never a
+   * resolved default: the email templates carry their own defaults, which differ from
+   * the login palette (a near-black button rather than the login blue). Returning
+   * defaults here would silently restyle every unbranded realm's email.
+   *
+   * Base tokens only. The email templates need nothing that derives, and light only —
+   * dark-mode support across email clients is too inconsistent to target.
+   */
+  public static Map<String, String> explicitLightTokens(Function<String, String> attr) {
+    Map<String, String> out = new LinkedHashMap<>();
+    for (String token : BASE_TOKENS) {
+      String v2 = attr.apply(V2_PREFIX + token);
+      String suffix = LEGACY_SUFFIX.get(token);
+      String legacy = suffix == null ? null : attr.apply(LEGACY_PREFIX + suffix);
+      String set = pickColor(v2, legacy);
+      if (set != null) out.put(token, set);
+    }
+    String radius = attr.apply(V2_PREFIX + "radius");
+    if (isLength(radius)) out.put("radius", radius.trim());
+    return out;
+  }
+
   /** Render the full {@code :root} + {@code .dark} shadcn block for a realm. */
   public static String render(Function<String, String> attr) {
     Resolution light = resolveMode(attr, false, null);

--- a/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
+++ b/src/test/java/io/phasetwo/keycloak/themes/resource/LoginThemeCssTest.java
@@ -1,5 +1,6 @@
 package io.phasetwo.keycloak.themes.resource;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -150,6 +151,57 @@ public class LoginThemeCssTest {
     String css = LoginThemeCss.render(attrs(map(LoginThemeCss.V2_PREFIX + "primary", "red}; }")));
     assertTrue(css.contains("--primary: #3b82f6;"), css);
     assertFalse(css.contains("red}"), css);
+  }
+
+  @Test
+  public void explicitLightTokensIsEmptyForAnUnbrandedRealm() {
+    // The email templates carry their own defaults, which differ from the login
+    // palette. Returning resolved defaults here would restyle every unbranded email.
+    assertTrue(LoginThemeCss.explicitLightTokens(attrs(map())).isEmpty());
+  }
+
+  @Test
+  public void explicitLightTokensReturnsOnlyWhatTheRealmSet() {
+    Map<String, String> t =
+        LoginThemeCss.explicitLightTokens(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "primary", "#7c3aed",
+                    LoginThemeCss.V2_PREFIX + "radius", "1rem")));
+    assertEquals("#7c3aed", t.get("primary"));
+    assertEquals("1rem", t.get("radius"));
+    // Untouched tokens are absent, not defaulted.
+    assertFalse(t.containsKey("background"));
+    assertFalse(t.containsKey("foreground"));
+    assertFalse(t.containsKey("primaryForeground"));
+  }
+
+  @Test
+  public void explicitLightTokensFallsBackToLegacy() {
+    Map<String, String> t =
+        LoginThemeCss.explicitLightTokens(
+            attrs(map(LoginThemeCss.LEGACY_PREFIX + "primaryColor", "#ff6600")));
+    assertEquals("#ff6600", t.get("primary"));
+  }
+
+  @Test
+  public void explicitLightTokensRejectsInvalidValues() {
+    Map<String, String> t =
+        LoginThemeCss.explicitLightTokens(
+            attrs(
+                map(
+                    LoginThemeCss.V2_PREFIX + "primary", "red}; }",
+                    LoginThemeCss.V2_PREFIX + "radius", "huge")));
+    assertTrue(t.isEmpty());
+  }
+
+  @Test
+  public void explicitLightTokensIgnoresDarkOverrides() {
+    // Email is light-only, so a dark-only realm contributes nothing.
+    Map<String, String> t =
+        LoginThemeCss.explicitLightTokens(
+            attrs(map(LoginThemeCss.V2_PREFIX + "darkPrimary", "#a78bfa")));
+    assertTrue(t.isEmpty());
   }
 
   @Test

--- a/themes/phasetwo-ui/src/email/html/template.ftl
+++ b/themes/phasetwo-ui/src/email/html/template.ftl
@@ -9,23 +9,37 @@
     _providerConfig.assets.logo.base64  → branding.logoLight  (data URI; also drives CID attachment)
     _providerConfig.assets.email.footer.line1 → branding.footerLine1
     _providerConfig.assets.email.footer.line2 → branding.footerLine2
-  All color values use hardcoded defaults for now (background, card, text, etc.).
+
+  Colors come from branding.theme, the shared brand tokens under
+  _providerConfig.assets.theme.v2.* resolved by LoginThemeCss -- the same code the login
+  page uses, so the two cannot drift. Email clients do not support CSS variables, so the
+  values are interpolated into inline styles here.
+
+  Only tokens the realm has explicitly set are passed, so the defaults below stand for
+  an unbranded realm. They deliberately differ from the login palette (a near-black
+  button rather than the login blue), which is why the resolved defaults are not used.
+
+  Light only: dark-mode support across email clients is too inconsistent to target, so
+  no dark<Token> override is read here and the template carries no dark variant.
+
+  Each lookup is parenthesised -- (branding.theme.primary)!'#171717' -- so a realm with
+  no tokens at all does not error on the missing intermediate map.
   -->
   <#assign branding=branding!{}>
     <#macro emailLayout>
       <html>
 
-      <body style="background-color:#f2f2f2;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Ubuntu,sans-serif;color:#1a1a1a">
+      <body style="background-color:${(branding.theme.muted)!'#f2f2f2'};font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Ubuntu,sans-serif;color:${(branding.theme.foreground)!'#1a1a1a'}">
         <style>
         a.btn {
-          color: #fafafa;
+          color: ${(branding.theme.primaryForeground)!'#fafafa'};
           padding: 8px 20px;
           font-size: 14px;
           line-height: 20px;
           font-weight: 500;
           text-decoration: none;
-          border-radius: 0.65rem;
-          background-color: #171717;
+          border-radius: ${(branding.theme.radius)!'0.65rem'};
+          background-color: ${(branding.theme.primary)!'#171717'};
           display: inline-block;
         }
         </style>
@@ -35,7 +49,7 @@
 ><table align="center" width="600" style="border-spacing:0;width:600px;" role="presentation"><tr><td><![endif]
 -->
             <table align="center" width="100%" role="presentation" cellspacing="0" cellpadding="0" border="0"
-              style="max-width:576px;background-color:#ffffff;border-radius:0.65rem;color:#1a1a1a;margin:0 auto;margin-bottom:64px;padding:48px 0 16px;width:100%;box-shadow:0 0 #0000,0 0 #0000,0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1);"
+              style="max-width:576px;background-color:${(branding.theme.background)!'#ffffff'};border-radius:${(branding.theme.radius)!'0.65rem'};color:${(branding.theme.foreground)!'#1a1a1a'};margin:0 auto;margin-bottom:64px;padding:48px 0 16px;width:100%;box-shadow:0 0 #0000,0 0 #0000,0 1px 3px 0 rgb(0 0 0/0.1),0 1px 2px -1px rgb(0 0 0/0.1);"
               id="emailContainer">
               <tbody>
                 <tr style="width:100%">
@@ -43,10 +57,10 @@
                     <table align="center" width="100%" style="padding:0 48px" border="0" cellpadding="0" cellspacing="0" role="presentation">
                       <tbody>
                         <tr>
-                          <td style="color:#1a1a1a;">
+                          <td style="color:${(branding.theme.foreground)!'#1a1a1a'};">
                             <img alt="Logo" src="cid:logoLight" style="border:none;display:block;outline:none;text-decoration:none;max-width:160px;max-height:60px;width:auto;height:auto;margin:0 auto;margin-bottom:24px;">
                             <#nested>
-                              <p style="font-size:13px;line-height:22px;margin:16px 0;text-align:center;opacity:0.7;padding-top:24px;margin-top:24px;border-top:solid 1px #e8e8e8;color:#1a1a1a;">
+                              <p style="font-size:13px;line-height:22px;margin:16px 0;text-align:center;opacity:0.7;padding-top:24px;margin-top:24px;border-top:solid 1px ${(branding.theme.border)!'#e8e8e8'};color:${(branding.theme.foreground)!'#1a1a1a'};">
                                 <#if branding.footerLine1?has_content>
                                   ${branding.footerLine1}
                                 <#else>


### PR DESCRIPTION
The last piece of action C. The email template hardcoded every colour and carried a TODO saying so:

> All color values use hardcoded defaults for now (background, card, text, etc.).

## How

`DefaultAttributesBuilderProvider` already builds a `branding` map for the FTL (logo, footer lines). It now also passes `branding.theme`, resolved by `LoginThemeCss.explicitLightTokens` — the same resolution the login page uses, so the two surfaces cannot drift.

Email clients don't support CSS variables, so values are interpolated into inline styles server-side rather than emitted as a `:root` block.

The mapping needs **only base tokens**, so no derivation is involved:

| Element | Token | Default kept |
| --- | --- | --- |
| Page backdrop | `muted` | `#f2f2f2` |
| Card panel | `background` | `#ffffff` |
| Body text | `foreground` | `#1a1a1a` |
| Button face | `primary` | `#171717` |
| Button label | `primaryForeground` | `#fafafa` |
| Footer rule | `border` | `#e8e8e8` |
| Corners | `radius` | `0.65rem` |

## Only explicitly-set tokens are passed

`explicitLightTokens` returns tokens with a real `v2` or legacy value, **never a resolved default**. This matters: the email defaults deliberately differ from the login palette — a near-black button rather than the login blue — so passing resolved defaults would have silently restyled every unbranded realm's email. With this, an unbranded realm renders byte-identically to today.

## Light only

Dark-mode support across email clients is too inconsistent to target, so `dark<Token>` overrides aren't read. A dark-only realm contributes nothing (there's a test for that).

## Details

- Lookups are parenthesised — `${(branding.theme.primary)!'#171717'}` — so a realm with no tokens doesn't error on the missing intermediate map. The unparenthesised form only defaults the *last* step.
- The "Powered by Phase Two" link keeps its own colour: that's our branding, not the customer's.
- While writing the header comment I claimed the template had a `prefers-color-scheme` block. It doesn't — I'd misread the button styles. Comment corrected rather than left asserting something false.

## Checks

`mvn compile` clean, spotless applied, **19/19 `LoginThemeCssTest` pass** (5 new: empty for unbranded, only-what-was-set, legacy fallback, invalid rejected, dark ignored). All 14 FTL interpolations verified balanced and well-formed.